### PR TITLE
Disable InsecureRequestWarning reporting

### DIFF
--- a/thunner
+++ b/thunner
@@ -34,6 +34,10 @@ import collections
 import sys
 import signal
 
+# Disable InsecureRequestWarning reporting
+import requests
+requests.packages.urllib3.disable_warnings()
+
 from Queue import Queue, Empty
 from threading import Thread
 from gmusicapi import Mobileclient


### PR DESCRIPTION
Prevent thunner from throwing the following error: `InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised.`
